### PR TITLE
fix: update changed metadata in modern hugo

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
   <meta name="description" content="{{ .Site.Params.DefaultDescription }}">	
   {{ end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 
@@ -62,7 +62,7 @@
   <!-- Facebook OpenGraph tags -->
   <meta property="og:title" content="{{ .Title }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ .URL }}/" />
+  <meta property="og:url" content="{{ .Permalink }}/" />
   <meta property="og:image" content="{{ .Site.Params.logo }}" />
 
   <!-- cookie consent -->


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

This is a fix for modern (> 100) versions of hugo. `.URL` is not there anymore, and the hugo variables are lowercase now.

⚠️ Do not merge until you upgrade to newer hugo.