### PR TITLE
feat: update core release to v2.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/devcows/hugo-universal-theme v0.0.0-20210408074747-23c6efbbe23c // indirect
-	github.com/owaspsamm/core v0.0.0-20210520122448-8de72e41633a // indirect
+	github.com/owaspsamm/core v0.0.0-20221119125116-2fab0af5b0c9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/devcows/hugo-universal-theme v0.0.0-20210408074747-23c6efbbe23c h1:78
 github.com/devcows/hugo-universal-theme v0.0.0-20210408074747-23c6efbbe23c/go.mod h1:MqYH15Evmut/wgYkFi7ArsX+k44HfRrH675FbVLBkq0=
 github.com/owaspsamm/core v0.0.0-20210520122448-8de72e41633a h1:RNba5qaMQd/o6b+y9Q177VOqDYsLhCFHMuSd+alS5qM=
 github.com/owaspsamm/core v0.0.0-20210520122448-8de72e41633a/go.mod h1:ECnrbqPPh1OnAru4vRFzMou6Bx2xBemoVDZRTcgYYJw=
+github.com/owaspsamm/core v0.0.0-20221119125116-2fab0af5b0c9 h1:fb4At+QMYFvqABEgWlSKc3RaS4DJWU9AvgMQiqCMr24=
+github.com/owaspsamm/core v0.0.0-20221119125116-2fab0af5b0c9/go.mod h1:ECnrbqPPh1OnAru4vRFzMou6Bx2xBemoVDZRTcgYYJw=


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Updated release to v2.0.7.

```
❯ hugo mod get github.com/owaspsamm/core@markdown/v2.0.7
hugo: downloading modules …
hugo: collected modules in 4335 ms
go: downloading github.com/owaspsamm/core v0.0.0-20221119125116-2fab0af5b0c9
go: upgraded github.com/owaspsamm/core v0.0.0-20210520122448-8de72e41633a => v0.0.0-20221119125116-2fab0af5b0c9
```