### PR TITLE
Resolves #97

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -7,8 +7,7 @@ title = "OWASP SAMM"
 disqusShortname = ""
 # Enable Google Analytics by entering your tracking code
 googleAnalytics = "UA-127457120-1"
-# Google Analytics 4
-googleAnalyticsID = "G-44N5RHDT94"
+# Google Analytics 4 in params
 
 # Define the number of posts per page
 paginate = 10
@@ -204,6 +203,9 @@ paginate = 10
 
 
 [params]
+    # Google Analytics 4
+    googleAnalyticsID = "G-44N5RHDT94"
+
     viewMorePostLink = "/blog/"
     author = "OWASP SAMM"
     defaultKeywords = ["owasp", "samm", "maturity", "model", "software"]

--- a/layouts/partials/analytics-gtag.html
+++ b/layouts/partials/analytics-gtag.html
@@ -1,9 +1,0 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.googleAnalyticsID }}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', '{{ .Site.Params.googleAnalyticsID }}');
-</script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,8 +1,4 @@
 <head>
-  {{ if and (hugo.IsProduction) (.Site.Params.googleAnalyticsID) }}
-  {{ partial "analytics-gtag.html" . }}
-  {{ end }}
-
   <meta charset="utf-8">
   <meta name="robots" content="all,follow">
   <meta name="googlebot" content="index,follow,snippet,archive">

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -37,3 +37,16 @@ window.cookieconsent.initialise({
   }
 });
 </script>
+
+ <!-- GA4 remove in July at the latest -->
+ {{ if and (hugo.IsProduction) (.Site.Params.googleAnalyticsID) }}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.GoogleAnalyticsID }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ .Site.Params.GoogleAnalyticsID }}');
+</script>
+{{ end }}


### PR DESCRIPTION
Adds tracking for GA4 without interrupting tracking for GA.
We need to change this once the old version expires.