### PR TITLE
Hugo modules job and deploy job changes

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: booxmedialtd/ws-action-parse-semver@v1
         with:
           input_string: ${{ github.event.client_payload.release }}
-          version_extractor_regex: '\/v(.*)$'
+          version_extractor_regex: 'v(.*)$'
       - name: Check release semver sanity
         env:
           RELEASE: "v${{ steps.semver_parser.outputs.fullversion }}"
@@ -44,7 +44,6 @@ jobs:
           cat go.mod 
       # Do not commit files until we can verify the previous steps are working
       - name: Commit updated files to git
-        if: false
         uses: EndBug/add-and-commit@v9
         with:
           add: '["go.mod", "go.sum"]'
@@ -52,6 +51,8 @@ jobs:
           message: 'New SAMM release: ${{ github.event.client_payload.release }}'
   deploy:
     runs-on: ubuntu-latest
+      needs: updateHugoMod
+      if: ${{ always() && (needs.updateHugoMod.result == 'success' || needs.updateHugoMod.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -51,8 +51,8 @@ jobs:
           message: 'New SAMM release: ${{ github.event.client_payload.release }}'
   deploy:
     runs-on: ubuntu-latest
-      needs: updateHugoMod
-      if: ${{ always() && (needs.updateHugoMod.result == 'success' || needs.updateHugoMod.result == 'skipped') }}
+    needs: updateHugoMod
+    if: ${{ always() && (needs.updateHugoMod.result == 'success' || needs.updateHugoMod.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
With this pull request the first job (updateHugoMod) will update with hugo module from the core repository. This way the model yaml files will be synced.

The second job (deploy) was made to depend on the first so it will run after the correct module is written to the go.mod file. If the first job is skipped the deploy command will run on its own (like it is running today when a push to main branch is made). 