### PR TITLE
fix sdl blog link on mappings page

### DIFF
--- a/content/en/blog/comparing-bsimm-and-samm.md
+++ b/content/en/blog/comparing-bsimm-and-samm.md
@@ -3,7 +3,7 @@ title = "Comparing BSIMM & SAMM"
 date = "2020-10-29T00:00:00+02:00"
 tags = ["BSIMM", "maturity", "model"]
 categories = ["guidance"]
-banner = "img/banners/undraw_Working_oh83.png"
+banner = "img/resources/mappings.png"
 author = "Brian Glas"
 +++
 

--- a/content/en/resources/mappings.md
+++ b/content/en/resources/mappings.md
@@ -13,7 +13,7 @@ weight = 3
 ### Mapping between Microsoft SDL and SAMM
 The SAMM core team has created mappings between Microsoft SDL and OWASP SAMM. You can find the mapping in <b>{{< external-link "https://docs.google.com/spreadsheets/d/1WiQcn7wFzSM8xg78SqkIM1QF2C48jBCYi_N_6kOq174" "this spreadsheet">}}</b>.
 
-You can also find more information about this mapping in the <b>[Microsoft SDL and OWASP SAMM Mapping: A Comprehensive Analysis](/blog/comparing-microsoft-sdl-and-samm/)</b> blog post.
+You can also find more information about this mapping in the <b>[Microsoft SDL and OWASP SAMM Mapping: A Comprehensive Analysis](/blog/2025/01/20/comparing-microsoft-sdl-and-samm/)</b> blog post.
 
 ### Mapping between BSIMM 14 and SAMM
 The SAMM core team has created mappings between BSIMM 14 and OWASP SAMM standards. You can find the mapping in <b>{{< external-link "https://docs.google.com/spreadsheets/d/1WiQcn7wFzSM8xg78SqkIM1QF2C48jBCYi_N_6kOq174" "this spreadsheet">}}</b>.


### PR DESCRIPTION
fixing the link to the microsoft sdl blog + changing the preview image for all mappings to be the mapping circle