### PR TITLE
Fix OWASP SAMM project link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains the source files for the OWASP SAMM Website.
 
-You will find more information at [owaspsamm.org](https://owaspsamm.org/) or the [OWASP SAMM project wiki page](https://www.owasp.org/index.php?title=Category:Software_Assurance_Maturity_Model)
+You will find more information at [owaspsamm.org](https://owaspsamm.org/) or the [OWASP SAMM project page](https://owasp.org/www-project-samm/)
 
 This will not help you with your twitter addiction, but our premier source for SAMM gossip and news is [@owaspSAMM](https://twitter.com/owaspsamm).
 


### PR DESCRIPTION
# Fix OWASP SAMM project link in README

## Summary

- Replace the retired OWASP wiki URL in `README.md`.
- Point readers to the current OWASP SAMM project page.

## Context

The README currently links to:

`https://www.owasp.org/index.php?title=Category:Software_Assurance_Maturity_Model`

That legacy OWASP wiki page is no longer the right project destination. The current OWASP project page is:

`https://owasp.org/www-project-samm/`

## Verification

- Documentation-only change.
- Checked the current OWASP SAMM project page.

Closes #106.