### PR TITLE
fix: persist CNAME in build to prevent domain release on deploy

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+owaspsamm.org


### PR DESCRIPTION
Builds run hugo --cleanDestinationDir and publish via actions-gh-pages, which strips any CNAME not present in public/. 